### PR TITLE
Authentication improvements.

### DIFF
--- a/xmpp.go
+++ b/xmpp.go
@@ -575,9 +575,6 @@ func (c *Client) init(o *Options) error {
 					dHash := dgh.Sum(nil)
 					dHashb64 := base64.StdEncoding.EncodeToString(dHash)
 					if dHashb64 != serverDgProtectHash {
-						println("raw", dgProtect)
-						println("calc:", dHashb64)
-						println("recv:", serverDgProtectHash)
 						return errors.New("SCRAM: downgrade protection hash mismatch")
 					}
 					dgh.Reset()

--- a/xmpp.go
+++ b/xmpp.go
@@ -535,6 +535,9 @@ func (c *Client) init(o *Options) error {
 					}
 				case strings.HasPrefix(serverReply, "s="):
 					salt, err = base64.StdEncoding.DecodeString(strings.SplitN(serverReply, "=", 2)[1])
+					if err != nil {
+						return err
+					}
 					if string(salt) == "" {
 						return errors.New("SCRAM: server sent empty salt")
 					}


### PR DESCRIPTION
Add support for XEP-0474

The upcoming ejabberd release supports XEP-0474 [1] wich requires support for 
the `d=` parameter. Currently we fail if an unknown parameter is set and `d=`
is unknown.

Instead of just not failing when `d=` is set I added support for the downgrade
protection.

[1] https://xmpp.org/extensions/xep-0474.html
