### PR TITLE
Tls-server-end-point improvements.

### DIFF
--- a/xmpp.go
+++ b/xmpp.go
@@ -462,14 +462,22 @@ func (c *Client) init(o *Options) error {
 					return errors.New(mechanism + ": unknown TLS version")
 				}
 				if serverEndPoint {
+					var h hash.Hash
+					// This material is not necessary for `tls-server-end-point` binding, but it is required to check that
+					// the TLS connection was not renegotiated. This function will fail if that's the case (see
+					// https://pkg.go.dev/crypto/tls#ConnectionState.ExportKeyingMaterial
+					_, err = tlsState.ExportKeyingMaterial("EXPORTER-Channel-Binding", nil, 32)
+					if err != nil {
+						return err
+					}
 					switch tlsState.PeerCertificates[0].SignatureAlgorithm {
 					case x509.SHA1WithRSA, x509.SHA256WithRSA, x509.ECDSAWithSHA1,
 						x509.ECDSAWithSHA256, x509.SHA256WithRSAPSS:
-						h := sha256.New()
+						h = sha256.New()
 					case x509.SHA384WithRSA, x509.ECDSAWithSHA384, x509.SHA384WithRSAPSS:
-						h := sha512.New384()
+						h = sha512.New384()
 					case x509.SHA512WithRSA, x509.ECDSAWithSHA512, x509.SHA512WithRSAPSS:
-						h := sha512.New()
+						h = sha512.New()
 					}
 					h.Write(tlsState.PeerCertificates[0].Raw)
 					keyingMaterial = h.Sum(nil)

--- a/xmpp.go
+++ b/xmpp.go
@@ -466,20 +466,14 @@ func (c *Client) init(o *Options) error {
 					case x509.SHA1WithRSA, x509.SHA256WithRSA, x509.ECDSAWithSHA1,
 						x509.ECDSAWithSHA256, x509.SHA256WithRSAPSS:
 						h := sha256.New()
-						h.Write(tlsState.PeerCertificates[0].Raw)
-						keyingMaterial = h.Sum(nil)
-						h.Reset()
 					case x509.SHA384WithRSA, x509.ECDSAWithSHA384, x509.SHA384WithRSAPSS:
 						h := sha512.New384()
-						h.Write(tlsState.PeerCertificates[0].Raw)
-						keyingMaterial = h.Sum(nil)
-						h.Reset()
 					case x509.SHA512WithRSA, x509.ECDSAWithSHA512, x509.SHA512WithRSAPSS:
 						h := sha512.New()
-						h.Write(tlsState.PeerCertificates[0].Raw)
-						keyingMaterial = h.Sum(nil)
-						h.Reset()
 					}
+					h.Write(tlsState.PeerCertificates[0].Raw)
+					keyingMaterial = h.Sum(nil)
+					h.Reset()
 				}
 				if len(keyingMaterial) == 0 {
 					return errors.New(mechanism + ": no keying material")


### PR DESCRIPTION
- SCRAM: Add support for tls-server-end-point channel binding.
- Simplify tls-server-end-point channel binding code.
- (Indirectly) check that TLS was not renegotioated when using "tls-server-end-point".
