### PR TITLE
Improve RFC5802 compatibility.

### DIFF
--- a/xmpp.go
+++ b/xmpp.go
@@ -580,8 +580,8 @@ func (c *Client) init(o *Options) error {
 						return errors.New("SCRAM: downgrade protection hash mismatch")
 					}
 					dgh.Reset()
-				default:
-					return errors.New("unexpected content in SCRAM challenge")
+				case strings.HasPrefix(serverReply, "m="):
+					return errors.New("SCRAM: server sent reserved 'm' attribute.")
 				}
 			}
 			if scramPlus {


### PR DESCRIPTION
According to RFC 5802 5.1 only the "m" attribute should
cause an authentication error.
