### PR TITLE
Add support for SASL2 and BIND2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/xmppo/go-xmpp
 go 1.21.5
 
 require (
-	github.com/google/uuid v1.6.0
 	golang.org/x/crypto v0.22.0
 	golang.org/x/net v0.24.0
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/xmppo/go-xmpp
 go 1.21.5
 
 require (
-	golang.org/x/crypto v0.21.0
-	golang.org/x/net v0.23.0
+	github.com/google/uuid v1.6.0
+	golang.org/x/crypto v0.22.0
+	golang.org/x/net v0.24.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
-golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
-golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
-golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
-golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+golang.org/x/crypto v0.22.0 h1:g1v0xeRhjcugydODzvb3mEM9SQ0HGp9s/nh3COQ/C30=
+golang.org/x/crypto v0.22.0/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
+golang.org/x/net v0.24.0 h1:1PcaxkF854Fu3+lvBIx5SYn9wRlBzzcnHZSiaFFAb0w=
+golang.org/x/net v0.24.0/go.mod h1:2Q7sJY5mzlzWjKtYUEXSlBWCdyaioyXzRB2RtU8KVE8=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 golang.org/x/crypto v0.22.0 h1:g1v0xeRhjcugydODzvb3mEM9SQ0HGp9s/nh3COQ/C30=
 golang.org/x/crypto v0.22.0/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
 golang.org/x/net v0.24.0 h1:1PcaxkF854Fu3+lvBIx5SYn9wRlBzzcnHZSiaFFAb0w=

--- a/xmpp.go
+++ b/xmpp.go
@@ -557,10 +557,10 @@ func (c *Client) init(o *Options) error {
 			}
 			if sasl2 {
 				if bind2 {
-					if o.Resource != "" {
-						resource = o.Resource
+					if o.UserAgentSW != "" {
+						resource = o.UserAgentSW
 					} else {
-						resource = uuid.NewString()
+						resource = "go-xmpp"
 					}
 					bind2Data = fmt.Sprintf("<bind xmlns='%s'><tag>%s</tag></bind>",
 						nsBind2, resource)

--- a/xmpp.go
+++ b/xmpp.go
@@ -16,6 +16,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
@@ -27,6 +28,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"math/big"
 	"net"
 	"net/http"
 	"net/url"
@@ -360,6 +362,16 @@ func (c *Client) Close() error {
 	return nil
 }
 
+func cnonce() string {
+	randSize := big.NewInt(0)
+	randSize.Lsh(big.NewInt(1), 64)
+	cn, err := rand.Int(rand.Reader, randSize)
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%016x", cn)
+}
+
 func (c *Client) init(o *Options) error {
 	var domain string
 	var user string
@@ -542,7 +554,7 @@ func (c *Client) init(o *Options) error {
 			default:
 				return errors.New("unsupported auth mechanism")
 			}
-			clientNonce := uuid.NewString()
+			clientNonce := cnonce()
 			if scramPlus {
 				switch {
 				case tls13 && !serverEndPoint:
@@ -1294,7 +1306,7 @@ func (c *Client) Send(chat Chat) (n int, err error) {
 
 	chat.Text = validUTF8(chat.Text)
 	stanza := fmt.Sprintf("<message to='%s' type='%s' id='%s' xml:lang='en'>"+subtext+"<body>%s</body>"+oobtext+thdtext+"</message>\n",
-		xmlEscape(chat.Remote), xmlEscape(chat.Type), uuid.NewString(), xmlEscape(chat.Text))
+		xmlEscape(chat.Remote), xmlEscape(chat.Type), cnonce(), xmlEscape(chat.Text))
 	if c.LimitMaxBytes != 0 && len(stanza) > c.LimitMaxBytes {
 		return 0, fmt.Errorf("stanza size (%v bytes) exceeds server limit (%v bytes)",
 			len(stanza), c.LimitMaxBytes)
@@ -1317,7 +1329,7 @@ func (c *Client) SendOOB(chat Chat) (n int, err error) {
 		oobtext += `</x>`
 	}
 	stanza := fmt.Sprintf("<message to='%s' type='%s' id='%s' xml:lang='en'>"+oobtext+thdtext+"</message>\n",
-		xmlEscape(chat.Remote), xmlEscape(chat.Type), uuid.NewString())
+		xmlEscape(chat.Remote), xmlEscape(chat.Type), cnonce())
 	if c.LimitMaxBytes != 0 && len(stanza) > c.LimitMaxBytes {
 		return 0, fmt.Errorf("stanza size (%v bytes) exceeds server limit (%v bytes)",
 			len(stanza), c.LimitMaxBytes)

--- a/xmpp.go
+++ b/xmpp.go
@@ -64,9 +64,6 @@ var DefaultConfig = &tls.Config{}
 // DebugWriter is the writer used to write debugging output to.
 var DebugWriter io.Writer = os.Stderr
 
-// Cookie is a unique XMPP session identifier
-type Cookie uint64
-
 // Client holds XMPP connection options
 type Client struct {
 	conn             net.Conn // connection to server
@@ -876,13 +873,13 @@ func (c *Client) init(o *Options) error {
 
 	if !bind2 {
 		// Generate a unique cookie
-		cookie := uuid.New()
+		cookie := uuid.NewString()
 
 		// Send IQ message asking to bind to the local user name.
 		if o.Resource == "" {
-			fmt.Fprintf(c.stanzaWriter, "<iq type='set' id='%x'><bind xmlns='%s'></bind></iq>\n", cookie, nsBind)
+			fmt.Fprintf(c.stanzaWriter, "<iq type='set' id='%s'><bind xmlns='%s'></bind></iq>\n", cookie, nsBind)
 		} else {
-			fmt.Fprintf(c.stanzaWriter, "<iq type='set' id='%x'><bind xmlns='%s'><resource>%s</resource></bind></iq>\n", cookie, nsBind, o.Resource)
+			fmt.Fprintf(c.stanzaWriter, "<iq type='set' id='%s'><bind xmlns='%s'><resource>%s</resource></bind></iq>\n", cookie, nsBind, o.Resource)
 		}
 		_, val, err = c.next()
 		if err != nil {
@@ -908,8 +905,8 @@ func (c *Client) init(o *Options) error {
 	}
 	if o.Session {
 		// if server support session, open it
-		cookie := uuid.New() // generate new id value for session
-		fmt.Fprintf(c.stanzaWriter, "<iq to='%s' type='set' id='%x'><session xmlns='%s'/></iq>\n", xmlEscape(domain), cookie, nsSession)
+		cookie := uuid.NewString() // generate new id value for session
+		fmt.Fprintf(c.stanzaWriter, "<iq to='%s' type='set' id='%s'><session xmlns='%s'/></iq>\n", xmlEscape(domain), cookie, nsSession)
 	}
 
 	// We're connected and can now receive and send messages.

--- a/xmpp.go
+++ b/xmpp.go
@@ -409,7 +409,7 @@ func (c *Client) init(o *Options) error {
 	var cbsSlice, mechSlice []string
 	var tlsConn *tls.Conn
 	// Use SASL2 if available
-	if f.Authentication.Mechanism != nil {
+	if f.Authentication.Mechanism != nil && c.IsEncrypted() {
 		sasl2 = true
 		mechSlice = f.Authentication.Mechanism
 		// Detect whether bind2 is available

--- a/xmpp.go
+++ b/xmpp.go
@@ -251,6 +251,8 @@ type Options struct {
 	// XEP-0388: XEP-0388: Extensible SASL Profile
 	// Unique stable identifier for the client installation
 	// MUST be a valid UUIDv4
+	// SASL2 will not be used when not set, as current server implementations
+	// (ejabberd and prosody) require it
 	UserAgentID string
 }
 

--- a/xmpp.go
+++ b/xmpp.go
@@ -250,6 +250,7 @@ type Options struct {
 
 	// XEP-0388: XEP-0388: Extensible SASL Profile
 	// Unique stable identifier for the client installation
+	// MUST be a valid UUIDv4
 	UserAgentID string
 }
 

--- a/xmpp.go
+++ b/xmpp.go
@@ -431,7 +431,7 @@ func (c *Client) init(o *Options) error {
 		return err
 	}
 	var mechanism, channelBinding, clientFirstMessage, clientFinalMessageBare, authMessage string
-	var bind2Data, resource, userAgentSW, userAgentDev string
+	var bind2Data, resource, userAgentSW, userAgentDev, userAgentID string
 	var serverSignature, keyingMaterial []byte
 	var scramPlus, ok, tlsConnOK, tls13, serverEndPoint, sasl2, bind2 bool
 	var cbsSlice, mechSlice []string
@@ -601,9 +601,12 @@ func (c *Client) init(o *Options) error {
 				if o.UserAgentDev != "" {
 					userAgentDev = fmt.Sprintf("<device>%s</device>", o.UserAgentDev)
 				}
+				if o.UserAgentID != "" {
+					userAgentID = fmt.Sprintf(" id='%s'", o.UserAgentID)
+				}
 				fmt.Fprintf(c.stanzaWriter,
-					"<authenticate xmlns='%s' mechanism='%s'><initial-response>%s</initial-response><user-agent id='%s'>%s%s</user-agent>%s</authenticate>\n",
-					nsSASL2, mechanism, base64.StdEncoding.EncodeToString([]byte(clientFirstMessage)), o.UserAgentID, userAgentSW, userAgentDev, bind2Data)
+					"<authenticate xmlns='%s' mechanism='%s'><initial-response>%s</initial-response><user-agent%s>%s%s</user-agent>%s</authenticate>\n",
+					nsSASL2, mechanism, base64.StdEncoding.EncodeToString([]byte(clientFirstMessage)), userAgentID, userAgentSW, userAgentDev, bind2Data)
 			} else {
 				fmt.Fprintf(c.stanzaWriter, "<auth xmlns='%s' mechanism='%s'>%s</auth>\n",
 					nsSASL, mechanism, base64.StdEncoding.EncodeToString([]byte(clientFirstMessage)))

--- a/xmpp.go
+++ b/xmpp.go
@@ -251,8 +251,6 @@ type Options struct {
 	// XEP-0388: XEP-0388: Extensible SASL Profile
 	// Unique stable identifier for the client installation
 	// MUST be a valid UUIDv4
-	// SASL2 will not be used when not set, as current server implementations
-	// (ejabberd and prosody) require it
 	UserAgentID string
 }
 
@@ -439,8 +437,7 @@ func (c *Client) init(o *Options) error {
 	var cbsSlice, mechSlice []string
 	var tlsConn *tls.Conn
 	// Use SASL2 if available
-	if f.Authentication.Mechanism != nil && c.IsEncrypted() &&
-		o.UserAgentID != "" {
+	if f.Authentication.Mechanism != nil && c.IsEncrypted() {
 		sasl2 = true
 		mechSlice = f.Authentication.Mechanism
 		// Detect whether bind2 is available

--- a/xmpp.go
+++ b/xmpp.go
@@ -1073,6 +1073,14 @@ func (c *Client) Recv() (stanza interface{}, err error) {
 			return Chat{}, err
 		}
 		switch v := val.(type) {
+		case *streamError:
+			errorMessage := v.Text.Text
+			if errorMessage == "" {
+				// v.Any is type of sub-element in failure,
+				// which gives a description of what failed if there was no text element
+				errorMessage = v.Any.Space
+			}
+			return Chat{}, errors.New("stream error: " + errorMessage)
 		case *clientMessage:
 			if v.Event.XMLNS == XMPPNS_PUBSUB_EVENT {
 				// Handle Pubsub notifications

--- a/xmpp.go
+++ b/xmpp.go
@@ -975,9 +975,9 @@ func (c *Client) startStream(o *Options, domain string) (*streamFeatures, error)
 	}
 
 	_, err := fmt.Fprintf(c.stanzaWriter, "<?xml version='1.0'?>"+
-		"<stream:stream to='%s' xmlns='%s'"+
+		"<stream:stream from='%s' to='%s' xmlns='%s'"+
 		" xmlns:stream='%s' version='1.0'>\n",
-		xmlEscape(domain), nsClient, nsStream)
+		xmlEscape(o.User), xmlEscape(domain), nsClient, nsStream)
 	if err != nil {
 		return nil, err
 	}

--- a/xmpp_information_query.go
+++ b/xmpp_information_query.go
@@ -2,8 +2,7 @@ package xmpp
 
 import (
 	"fmt"
-
-	"github.com/google/uuid"
+	"strconv"
 )
 
 const (
@@ -14,7 +13,7 @@ const (
 
 func (c *Client) Discovery() (string, error) {
 	// use UUIDv4 for a pseudo random id.
-	reqID := uuid.NewString()
+	reqID := strconv.FormatUint(uint64(getCookie()), 10)
 	return c.RawInformationQuery(c.jid, c.domain, reqID, IQTypeGet, XMPPNS_DISCO_ITEMS, "")
 }
 

--- a/xmpp_information_query.go
+++ b/xmpp_information_query.go
@@ -2,7 +2,8 @@ package xmpp
 
 import (
 	"fmt"
-	"strconv"
+
+	"github.com/google/uuid"
 )
 
 const (
@@ -12,8 +13,8 @@ const (
 )
 
 func (c *Client) Discovery() (string, error) {
-	// use getCookie for a pseudo random id.
-	reqID := strconv.FormatUint(uint64(getCookie()), 10)
+	// use UUIDv4 for a pseudo random id.
+	reqID := uuid.NewString()
 	return c.RawInformationQuery(c.jid, c.domain, reqID, IQTypeGet, XMPPNS_DISCO_ITEMS, "")
 }
 


### PR DESCRIPTION
I added some basic support for [XEP-0388: Extensible SASL Profile](https://xmpp.org/extensions/xep-0386.html) and [XEP-0386: Bind 2](https://xmpp.org/extensions/xep-0386.html).

@mattn as this would introduce a new dependency ([google/uuid](https://github.com/google/uuid) as XEP-0388 requires the use of a valid UUIDv4) I'd like to ask your opinion.