### PR TITLE
fix(example): tls.Config should be pointer

### DIFF
--- a/_example/example-gui.go
+++ b/_example/example-gui.go
@@ -69,7 +69,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	xmpp.DefaultConfig = tls.Config{
+	xmpp.DefaultConfig = &tls.Config{
 		ServerName:         "talk.google.com",
 		InsecureSkipVerify: false,
 	}

--- a/_example/example.go
+++ b/_example/example.go
@@ -43,7 +43,7 @@ func main() {
 	}
 
 	if !*notls {
-		xmpp.DefaultConfig = tls.Config{
+		xmpp.DefaultConfig = &tls.Config{
 			ServerName:         serverName(*server),
 			InsecureSkipVerify: false,
 		}


### PR DESCRIPTION
I'm compiling _example/example.go and get fail, tls.Config should be pointer

```bash
cd _example;

 _example git:(master) go build -o example ./example.go 
# command-line-arguments
./example.go:46:24: cannot use tls.Config{…} (value of struct type tls.Config) as *tls.Config value in assignment
```